### PR TITLE
logger: now perform console posts using `cout` and `cerr`. all statem…

### DIFF
--- a/include/c74_min.h
+++ b/include/c74_min.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <unordered_map>
 
+
 namespace c74 {
 namespace min {
 	using uchar = unsigned char;
@@ -25,18 +26,31 @@ namespace min {
 	using samples = std::vector<sample>;
 }}
 
+
+/// A standard interface for flagging serious runtime snafus.
+/// At the moment this is hardwired to throw an exception but offers us the ability to
+/// change that behavior later or specialize it for certain contexts.
+///
+/// Because this throws an exception you should **not** call this function in an audio perform routine.
+void error(std::string description) {
+	throw std::runtime_error(description);
+}
+
+
 #include "c74_min_symbol.h"
 #include "c74_min_atom.h"
 #include "c74_min_map.h"
-#include "c74_min_logger.h"
 #include "c74_min_dictionary.h"
+
 
 namespace c74 { 
 namespace min {
 	static max::t_class* this_class = nullptr;
 }}
 
+
 #include "c74_min_object_components.h"	// Shared components of Max objects
+#include "c74_min_logger.h"
 #include "c74_min_operator_perform.h"	// Perform-based MSP object add-ins
 #include "c74_min_operator_sample.h"	// Sample-based MSP object add-ins
 #include "c74_min_operator_matrix.h"	// Jitter MOP

--- a/include/c74_min_logger.h
+++ b/include/c74_min_logger.h
@@ -9,73 +9,34 @@
 namespace c74 {
 namespace min {
 
-
-	/// Logging utility to deliver output messages.
-	/// In most cases the logged output will be delivered to the Max window.
+	
+	class logger_line_ending {};	/// A type to represent line endings for the #logger class.
+	logger_line_ending endl;		/// An instance of a line ending for convenience
+	
+	
+	/// Logging utility to deliver console messages
+	/// in such a way that they are mirrored to the Max window.
 	class logger {
 	public:
 
+		
 		/// The output type of the message.
 		/// These are not `levels` as in some languages (e.g. Ruby) but distinct targets.
 		enum type {
-			message = 0		///< A regular console post to the Max Window.
-			,warning		///< A highlighted warning post to the Max Window.
-			,error			///< A highlighted and trappable error post to the Max Window.
-			,console		///< A console post to the OS system console.
-			,obtrusive		///< A pop-up error in the patcher windows, to be used exceedingly sparingly.
+			message = 0,	///< A regular console post to the Max Window.
+			error			///< A highlighted and trappable error post to the Max Window.
 		};
 
 
-		/// Constructor: typically you do not call this directly, but via the post() method of object_base
-		/// @param obj	The Max object header for your instance
-		/// @param type	The type of console output to deliver
-		logger(max::t_object* obj, logger::type type = type::message)
-		: maxobj(obj)
+		/// Constructor: typically you do not call this directly,
+		/// it used by #min::object to create #cout and #cerr
+		/// @param an_owner		Your object instance
+		/// @param type			The type of console output to deliver
+		logger(object_base* an_owner, logger::type type)
+		: owner(*an_owner)
 		, target(type)
 		{}
 		
-		
-		// No copy constructor
-		logger(logger& other) = delete;
-		
-		
-		// Move constructor is required because we return our instance, by value,
-		// from the post() method of object_base
-		logger(logger&& other)
-		: maxobj(other.maxobj)
-		, target(other.target)
-		, stream(std::move(other.stream))
-		{}
-		
-		
-		// The call to post() is complete, thus our message is complete and we go out of scope,
-		// meaning we can now deliver the message.
-		~logger() {
-			const char* msgstr = stream.str().c_str();
-
-			switch(target) {
-				case message:
-					std::cout << msgstr << std::endl;
-					max::object_post(maxobj, msgstr);
-					break;
-				case warning:
-					std::cout << msgstr << std::endl;
-					max::object_warn(maxobj, msgstr);
-					break;
-				case error:
-					std::cerr << msgstr << std::endl;
-					max::object_error(maxobj, msgstr);
-					break;
-				case console:
-					max::cpost(msgstr);
-					break;
-				case obtrusive:
-					std::cerr << msgstr << std::endl;
-					max::object_error_obtrusive(maxobj, msgstr);
-					break;
-			}
-		}
-
 
 		/// Use the insertion operator as for any other stream to build the output message
 		/// @param	x	A token to be added to the output stream. d
@@ -86,21 +47,31 @@ namespace min {
 		}
 
 
+		/// Pass #endl to the insertion operator to complete the console post and flush it.
+		/// @param x	The #min::endl token
+		logger& operator<<(const logger_line_ending& x) {
+			const std::string& s = stream.str();
+			
+			switch(target) {
+				case message:
+					std::cout << s << std::endl;
+					max::object_post(owner, s.c_str());
+					break;
+				case error:
+					std::cerr << s << std::endl;
+					max::object_error(owner, s.c_str());
+					break;
+			}
+
+			stream.str("");
+			return *this;
+		}
+
 	private:
-		max::t_object*		maxobj;
+		object_base&		owner;
 		logger::type		target;
 		std::stringstream	stream;
 	};
 	
-	
-	/// A standard interface for flagging serious runtime snafus.
-	/// At the moment this is hardwired to throw an exception but offers us the ability to
-	/// change that behavior later or specialize it for certain contexts.
-	///
-	/// Because this throws an exception you should **not** call this function in an audio perform routine.
-	
-	void error(std::string description) {
-		throw std::runtime_error(description);
-	}
 
 }} // namespace c74::min

--- a/include/c74_min_object.h
+++ b/include/c74_min_object.h
@@ -342,6 +342,11 @@ namespace min {
 		
 		virtual ~object() {
 		}
+
+		
+	protected:
+		logger	cout = { this, logger::type::message};
+		logger	cerr = { this, logger::type::error};
 		
 		
 	private:

--- a/include/c74_min_object_components.h
+++ b/include/c74_min_object_components.h
@@ -67,10 +67,6 @@ namespace min {
 		int current_inlet() {
 			return proxy_getinlet((max::t_object*)m_maxobj);
 		}
-        
-		logger post(logger::type target = logger::type::message) {
-            return logger(m_maxobj, target);
-        }
 		
 		operator max::t_object* () {
 			return m_maxobj;


### PR DESCRIPTION
…ents must end with `endl`. see #4.
