### PR TITLE
store class name in static variable to fix crash in 32 bit

### DIFF
--- a/include/c74_min.h
+++ b/include/c74_min.h
@@ -121,6 +121,7 @@ namespace c74 {
 namespace min {
 	static max::t_class*	this_class = nullptr;
 	static bool				this_class_init = false;
+    static max::t_symbol*   this_class_name = nullptr;
 }}
 
 

--- a/include/c74_min_object_wrapper.h
+++ b/include/c74_min_object_wrapper.h
@@ -412,8 +412,7 @@ namespace min {
 				class_addmethod(c, (method)wrapper_method_generic<min_class_type>, a_message.first.c_str(), a_message.second->type(), 0);
 		}
 		
-		// the menufun isn't used anymore, so we are repurposing it here to store the name of the jitter class we wrap
-		c->c_menufun = (max::method)max::gensym(cppname);
+        this_class_name = max::gensym(cppname);
 		
 		max::class_register(max::CLASS_BOX, c);
 		

--- a/include/c74_min_operator_gl.h
+++ b/include/c74_min_operator_gl.h
@@ -98,7 +98,7 @@ namespace min {
 	template<class min_class_type>
 	void*
 	max_jit_gl_new(max::t_symbol* s, long argc, max::t_atom* argv) {
-		auto cppname = (max::t_symbol*)this_class->c_menufun;
+        auto cppname = this_class_name;
 		max_jit_wrapper* self = (max_jit_wrapper*)max::max_jit_object_alloc(this_class, cppname);
 		void* o = max::jit_object_new(cppname, s);
 		max_jit_mop_setup_simple(self, o, argc, argv);
@@ -182,8 +182,7 @@ namespace min {
 		
 		max::class_addmethod(this_class, (max::method)max::max_jit_mop_assist, "assist", max::A_CANT, 0);	// standard matrix-operator (mop) assist fn
 		
-		// the menufun isn't used anymore, so we are repurposing it here to store the name of the jitter class we wrap
-		this_class->c_menufun = (max::method)max::gensym(cppname);
+        this_class_name = max::gensym(cppname);
 		
 		max::class_register(max::CLASS_BOX, this_class);
 	}

--- a/include/c74_min_operator_matrix.h
+++ b/include/c74_min_operator_matrix.h
@@ -168,7 +168,7 @@ namespace min {
 	void* max_jit_mop_new(max::t_symbol* s, long argc, max::t_atom* argv) {
 		atom_reference		args(argc, argv);
         long				attrstart	= attr_args_offset((short)args.size(), args.begin());
-		auto				cppname		= (max::t_symbol*)this_class->c_menufun;
+        auto				cppname		= this_class_name;
 		max_jit_wrapper*	self		= (max_jit_wrapper*)max::max_jit_object_alloc(this_class, cppname);
 		void*				o			= max::jit_object_new(cppname, s);
 		


### PR DESCRIPTION
this incorrectly references ticket #56 in min-devkit.

jitter mop objects crash 32 bit mac in max_jit_mop_new.
looks like the class name can't be stored in the this_class->c_menufun method pointer.
