### PR TITLE
provide "has_call" method to object base, allow jitter-mops to overri…

### DIFF
--- a/include/c74_min_object_components.h
+++ b/include/c74_min_object_components.h
@@ -151,6 +151,11 @@ namespace min {
 			atoms as = {arg};
 			return try_call(name, as);
 		}
+        
+        bool has_call(const std::string& name) {
+            auto found_message = m_messages.find(name);
+            return (found_message != m_messages.end());
+        }
 
 	protected:
 		max::t_object*										m_maxobj; // initialized prior to placement new

--- a/include/c74_min_object_wrapper.h
+++ b/include/c74_min_object_wrapper.h
@@ -360,12 +360,17 @@ namespace min {
 		// If no matrix inputs are declared, the mop is a generator
 		bool ownsinput = (inletcount==0);
 		
-		//add mop
-		auto mop = max::jit_object_new(max::_jit_sym_jit_mop, inletcount, outletcount);
-		max::jit_class_addadornment(this_jit_class, mop);
-		
-		//add methods
-		max::jit_class_addmethod(this_jit_class, (method)jit_matrix_calc<min_class_type>, "matrix_calc", max::A_CANT, 0);
+        if(instance->has_call("jitclass_setup")) {
+            instance->try_call("jitclass_setup", this_jit_class);
+        }
+        else {
+            //add mop
+            auto mop = max::jit_object_new(max::_jit_sym_jit_mop, inletcount, outletcount);
+            max::jit_class_addadornment(this_jit_class, mop);
+            
+            //add methods
+            max::jit_class_addmethod(this_jit_class, (method)jit_matrix_calc<min_class_type>, "matrix_calc", max::A_CANT, 0);
+        }
 		
 		for (auto& an_attribute : instance->attributes()) {
 			std::string		attr_name = an_attribute.first;
@@ -388,7 +393,6 @@ namespace min {
 		}
 		
 		jit_class_register(this_jit_class);
-		instance->try_call("jitclass_setup", this_jit_class);
 	
 		
 		// 2. Max Wrapper Class
@@ -404,22 +408,31 @@ namespace min {
 		
 		max::max_jit_class_obex_setup(c, calcoffset(max_jit_wrapper, obex));
 		
-		// for generator mops, override jit_matrix and outputmatrix
-		long flags = (ownsinput ? max::MAX_JIT_MOP_FLAGS_OWN_OUTPUTMATRIX | max::MAX_JIT_MOP_FLAGS_OWN_JIT_MATRIX : 0);
-		
-		max::max_jit_class_mop_wrap(c, this_jit_class, flags);	// attrs & methods for name, type, dim, planecount, bang, outputmatrix, etc
-		max::max_jit_class_wrap_standard(c, this_jit_class, 0);		// attrs & methods for getattributes, dumpout, maxjitclassaddmethods, etc
-		
+        if(instance->has_call("maxclass_setup")) {
+            instance->try_call("maxclass_setup", c);
+        }
+        else {
+            // for generator mops, override jit_matrix and outputmatrix
+            long flags = (ownsinput ? max::MAX_JIT_MOP_FLAGS_OWN_OUTPUTMATRIX | max::MAX_JIT_MOP_FLAGS_OWN_JIT_MATRIX : 0);
+            
+            max::max_jit_class_mop_wrap(c, this_jit_class, flags);	// attrs & methods for name, type, dim, planecount, bang, outputmatrix, etc
+            max::max_jit_class_wrap_standard(c, this_jit_class, 0);		// attrs & methods for getattributes, dumpout, maxjitclassaddmethods, etc
+            
+            if(ownsinput)
+                max::max_jit_class_addmethod_usurp_low(c, (method)min_jit_mop_outputmatrix<min_class_type>, (char*)"outputmatrix");
+        }
+        
 		max::class_addmethod(c, (method)max::max_jit_mop_assist, "assist", max::A_CANT, 0);	// standard matrix-operator (mop) assist fn
-		
-		if(ownsinput)
-			max::max_jit_class_addmethod_usurp_low(c, (method)min_jit_mop_outputmatrix<min_class_type>, (char*)"outputmatrix");
 		
 		for (auto& a_message : instance->messages()) {
 			MIN_WRAPPER_ADDMETHOD(c, dictionary,			dictionary,							A_SYM)
 			else MIN_WRAPPER_ADDMETHOD(c, notify,			self_sym_sym_ptr_ptr___err,			A_CANT)
 			else MIN_WRAPPER_ADDMETHOD(c, patchlineupdate,	self_ptr_long_ptr_long_ptr_long,	A_CANT)
 			else if (a_message.first == "maxclass_setup")	; // for min class construction only, do not add for exposure to max
+            else if (a_message.first == "jitclass_setup")	; // for min class construction only, do not add for exposure to max
+            else if (a_message.first == "mob_setup")        ; // for min class construction only, do not add for exposure to max
+            else if (a_message.first == "maxob_setup")      ; // for min class construction only, do not add for exposure to max
+            else if (a_message.first == "setup")            ; // for min class construction only, do not add for exposure to max
 			else
 				class_addmethod(c, (method)wrapper_method_generic<min_class_type>, a_message.first.c_str(), a_message.second->type(), 0);
 		}
@@ -429,7 +442,6 @@ namespace min {
 		max::class_register(max::CLASS_BOX, c);
 		
 		this_class = c;
-		instance->try_call("maxclass_setup", c);
 
 		// documentation update (if neccessary)
 		doc_update<min_class_type>(*instance, maxname, cppname);

--- a/include/c74_min_operator_matrix.h
+++ b/include/c74_min_operator_matrix.h
@@ -171,11 +171,20 @@ namespace min {
         auto				cppname		= this_class_name;
 		max_jit_wrapper*	self		= (max_jit_wrapper*)max::max_jit_object_alloc(this_class, cppname);
 		void*				o			= max::jit_object_new(cppname, s);
-		
-		max_jit_mop_setup_simple(self, o, args.size(), args.begin());
-		max_jit_attr_args(self, (short)args.size(), args.begin());
+		auto                job = (minwrap<min_class_type>*)o;
         
-        auto	job = (minwrap<min_class_type>*)o;
+        job->min_object.postinitialize();
+        
+        if(job->min_object.has_call("mob_setup")) {
+            atoms atomargs(args.begin(), args.begin()+attrstart);
+            atomargs.push_back(atom{self});
+            job->min_object.try_call("mob_setup", atomargs);
+        }
+        else {
+            max_jit_mop_setup_simple(self, o, args.size(), args.begin());
+        }
+        
+        max_jit_attr_args(self, (short)args.size(), args.begin());
         job->min_object.try_call("maxob_setup", atoms(args.begin(), args.begin()+attrstart));
         
 		return self;


### PR DESCRIPTION
…de default behavior by providing handlers for specific setup stages

hey Tim, this is my solution to allow for the functionality needed for jit.mo.join, and still using the min-object framework.

basically added a method to check if certain override messages are defined in the object, and to use them if so. 

please feel free to modify however you see fit.
