### PR TITLE
Fix for Cycling74/min-api/issue #99

### DIFF
--- a/include/c74_min_catch.h
+++ b/include/c74_min_catch.h
@@ -23,6 +23,7 @@ bool require_vector_approx(T source, T reference) {
 		return false;
 
 	for (auto i=0; i<source.size(); ++i) {
+		INFO("when i == " << i);
 		REQUIRE( source[i] == Approx(reference[i]) );
 		if (source[i] != Approx(reference[i]))
 			return false;


### PR DESCRIPTION
adds a message to specify which sample caused failure in REQUIRE_VECTOR_APPROX.

See Cycling74/min-api/issue #99 for how this changes the log output.