### PR TITLE
make atom.type() const

### DIFF
--- a/include/c74_min_atom.h
+++ b/include/c74_min_atom.h
@@ -226,7 +226,7 @@ namespace c74 { namespace min {
 
 		
 		/// Return the type of the data contained in the atom.
-		message_type type() {
+		message_type type() const {
 			return static_cast<message_type>(a_type);
 		}
 		


### PR DESCRIPTION
I think this method should be const. Otherwise one would not be able to check the types of const args in messages, attributes etc. 

for example: 
```c++
explicit thing(const c74::min::atoms& args = {}) {
    if(args[0].type() == c74::min::message_type::int_argument){  // wont compile because args is qualified const
        //do stuff
    }
}
```
