### PR TITLE
max name wasn't being passed in the correct location

### DIFF
--- a/include/c74_min_api.h
+++ b/include/c74_min_api.h
@@ -175,11 +175,11 @@ namespace c74::min {
             double alpha() const {
                 return m_color.alpha;
             }
-          
+
             bool operator==(const color& b) const {
                 return red() == b.red() && green() == b.green() && blue() == b.blue() && alpha() == b.alpha();
             }
-          
+
             bool operator!=(const color& b) const {
                 return red() != b.red() || green() != b.green() || blue() != b.blue() || alpha() != b.alpha();
             }
@@ -429,5 +429,5 @@ void wrap_as_max_external(const char* cppname, const char* maxname, void* resour
 
 #define MIN_EXTERNAL_CUSTOM(cpp_classname, max_name)                                                                                       \
     void ext_main(void* r) {                                                                                                               \
-        c74::min::wrap_as_max_external<cpp_classname>(#max_name, __FILE__, r);                                                             \
+        c74::min::wrap_as_max_external<cpp_classname>(#cpp_classname, #max_name, r);                                                       \
     }


### PR DESCRIPTION
the signature for the method being called is :
`    void wrap_as_max_external(const char* cppname, const char* maxname, void* resources, min_class_type* instance = nullptr) {
`

 `MIN_EXTERNAL_CUSTOM` was passing `#maxname` for the `cppname` arg and `__FILE__` for the maxname.
In practice, this updated version allows me to call:

`MIN_EXTERNAL_CUSTOM(myclass, whateveriwant~)` and then in max (if the project is named correctly) have an object called `whateveriwant~`