### PR TITLE
Fixed missing argument for outlet_do_send

### DIFF
--- a/include/c74_min_impl.h
+++ b/include/c74_min_impl.h
@@ -151,7 +151,7 @@ namespace c74::min {
 
 
     bool atom::operator==(const max::t_atom& b) const {
-        return this->a_type == this->a_type && this->a_w.w_obj == b.a_w.w_obj;
+        return this->a_w.w_obj == b.a_w.w_obj;
     }
 
 

--- a/include/c74_min_outlet.h
+++ b/include/c74_min_outlet.h
@@ -98,7 +98,7 @@ namespace c74::min {
         {}
 
         void callback() {
-            outlet_do_send(m_value);
+            outlet_do_send(this->m_maxoutlet,m_value);
             m_set = false;
         }
 


### PR DESCRIPTION
Would it be a typo? This never caused errors with Xcode clang 11 and LLVM clang 9.0 but does with LLVM clang 10.0.
Maybe because this template has not instantiated for a long time.