### PR TITLE
c74_min_atom: use sized integers instead of `long long`

### DIFF
--- a/include/c74_min_atom.h
+++ b/include/c74_min_atom.h
@@ -53,19 +53,12 @@ namespace c74::min {
             return *this;
         }
 
-#ifdef C74_X64
-        atom& operator=(const long long value) {
+        atom& operator=(const int64_t value) {
             atom_setlong(this, value);
             return *this;
         }
-#else
-        atom& operator=(const long value) {
-            atom_setlong(this, value);
-            return *this;
-        }
-#endif
 
-        atom& operator=(const int value) {
+        atom& operator=(const int32_t value) {
             atom_setlong(this, value);
             return *this;
         }


### PR DESCRIPTION
note: this depends on https://github.com/Cycling74/max-api/pull/20

---

`long`, `long long` and `int64_t` may be distinct types, even if they are
all 64bit types in LP64 data model.
using the correct types we are a little closer to the stl types
