### PR TITLE
Add C74_WARNINGS_AS_ERRORS option and fix MIN_TEST compile flag

### DIFF
--- a/script/min-posttarget.cmake
+++ b/script/min-posttarget.cmake
@@ -6,14 +6,14 @@ include(${C74_MAX_API_DIR}/script/max-posttarget.cmake)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
 
+option(C74_WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
+
 if (APPLE)
-    if ("${PROJECT_NAME}" MATCHES "min.")
-        set(MAKE_ALL_WARNINGS_ERRORS "-Werror")
-    else ()
-        set(MAKE_ALL_WARNINGS_ERRORS "")
+    set(C74_XCODE_WARNING_CFLAGS "-Wall -Wmissing-field-initializers -Wno-unused-lambda-capture -Wno-unknown-warning-option")
+    if (${C74_WARNINGS_AS_ERRORS})
+        set(C74_XCODE_WARNING_CFLAGS "${C74_XCODE_WARNING_CFLAGS} -Werror")
     endif ()
 
     # enforce a strict warning policy
-    set_target_properties(${PROJECT_NAME} PROPERTIES XCODE_ATTRIBUTE_WARNING_CFLAGS "-Wall ${MAKE_ALL_WARNINGS_ERRORS} -Wmissing-field-initializers -Wno-unused-lambda-capture -Wno-unknown-warning-option")
-    # -Wmost -Wno-four-char-constants -Wno-unknown-pragmas $(inherited)
+    set_target_properties(${PROJECT_NAME} PROPERTIES XCODE_ATTRIBUTE_WARNING_CFLAGS ${C74_XCODE_WARNING_CFLAGS})
 endif ()

--- a/test/min-object-unittest.cmake
+++ b/test/min-object-unittest.cmake
@@ -16,10 +16,6 @@ if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${TEST_NAME}.cpp")
 		"${C74_MIN_API_DIR}/test"
 		# "${C74_MIN_API_DIR}/test/mock"
 	)
-    
-	add_definitions(
-		-DMIN_TEST
-	)
 
 	set(TEST_SOURCE_FILES "")
 	FOREACH(SOURCE_FILE ${SOURCE_FILES})
@@ -45,6 +41,8 @@ if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${TEST_NAME}.cpp")
 	endif ()
 
 	add_executable(${TEST_NAME} ${TEST_NAME}.cpp ${TEST_SOURCE_FILES})
+
+	target_compile_definitions(${TEST_NAME} PUBLIC -DMIN_TEST)
 
 	set_property(TARGET ${TEST_NAME} PROPERTY CXX_STANDARD 17)
 	set_property(TARGET ${TEST_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
This PR makes the following changes:

- It adds the C74_WARNINGS_AS_ERRORS option. Users can enable this option if they'd like to have all warnings to be treated as errors. The previous behavior enabled this only for projects with `min.` in the name - for usage in min-devkit. Now, min-devkit should simply use this option.
- It ensures that the `MIN_TEST` compile flag is only set for the test target. Before, `MIN_TEST` was also set for the object itself, resulting in incorrect code getting called in `c74_min_attribute.h`. Now, setting an attribute's value with the `set` method calls the `object_attr_setvalueof` method, which notifies the object of the attribute change. This fixes an issue where setting the attribute from inside the object itself (for example, `my_attribute = 1.0`) wouldn't trigger a notification.