### PR TITLE
Introduce attribute::set_range() and fix two bugs

### DIFF
--- a/include/c74_min_attribute.h
+++ b/include/c74_min_attribute.h
@@ -596,7 +596,7 @@ namespace c74::min {
             if (!writable() && !override_readonly)
                 return;    // we're all done... unless this is a readonly attr that we are forcing to update
 
-            if (repetitions == allow_repetitions::no && compare_to_current_value(args))
+            if (repetitions == allow_repetitions::no && compare_to_current_value(constrain(args)))
                 return;
 
 #ifndef MIN_TEST    // At this time the Mock Kernel does not implement object_attr_setvalueof(), so we can't use it for unit tests

--- a/include/c74_min_attribute.h
+++ b/include/c74_min_attribute.h
@@ -771,7 +771,7 @@ namespace c74::min {
 
         template<class U = T, typename enable_if<!is_same<limit_type<U>, limit::none<U>>::value, int>::type = 0>
         void constrain(atoms& args) const {
-            // TODO: type checking on the above so that it is not applied to vectors or colors
+            static_assert(std::is_arithmetic<T>::value, "limiting can only be applied to arithmetic types");
             args[0] = limit_type<T>::apply(args[0], m_range[0], m_range[1]);
         }
 

--- a/include/c74_min_attribute.h
+++ b/include/c74_min_attribute.h
@@ -156,13 +156,13 @@ namespace c74::min {
         // All attributes must define what happens when you set their value.
         // Args may be modified if the range is constrained
 
-        virtual attribute_base& operator=(atoms& args) = 0;
+        virtual attribute_base& operator=(const atoms& args) = 0;
 
 
         // All attributes must define what happens when you set their value.
         // NOTE: args may be modified after this call due to range limiting behavior
 
-        virtual void set(atoms& args, const bool notify = true, const bool override_readonly = false) = 0;
+        virtual void set(const atoms& args, const bool notify = true, const bool override_readonly = false) = 0;
 
 
         // All attributes must define what happens when you get their value.
@@ -335,7 +335,7 @@ namespace c74::min {
     class attribute_threadsafe_helper;
 
     template<typename T, threadsafe threadsafety, template<typename> class limit_type, allow_repetitions repetitions>
-    void attribute_threadsafe_helper_do_set(attribute_threadsafe_helper<T, threadsafety, limit_type, repetitions>* helper, atoms& args);
+    void attribute_threadsafe_helper_do_set(attribute_threadsafe_helper<T, threadsafety, limit_type, repetitions>* helper, const atoms& args);
 
 
     /// An Attribute.
@@ -504,7 +504,7 @@ namespace c74::min {
 
         void set_range(const std::vector<T>& range) {
             m_range = range;
-            auto value = static_cast<atoms>(*this);
+            const auto value = static_cast<atoms>(*this);
             set(value);
         }
 
@@ -559,24 +559,8 @@ namespace c74::min {
         /// Set the attribute value using atoms.
         /// @param	args	The new value to be assigned to the attribute.
 
-        attribute& operator=(atoms& args) override {
+        attribute& operator=(const atoms& args) override {
            set(args);
-            return *this;
-        }
-
-
-        // DO NOT USE
-		// This is an internal method
-        //
-        // This exists because MIN_FUNCTION, which is used by every attribute setter in user code,
-        // declares its args to be const to make it clear to users that they shouldn't be changing the args.
-        // We are priviledged in this scenario because we made the atoms as a copy of what Max provided us and
-        // we know it is safe to use them -- and potentially modify them when range limiting is applied.
-        //
-        // For user code, please use the version above and pass mutable atoms
-        
-        attribute& operator=(const atoms& args) {
-            set(const_cast<atoms&>(args));
             return *this;
         }
 
@@ -608,7 +592,7 @@ namespace c74::min {
         ///								Setting this to true will allow you to override the readonly flag and set the attribute value
         ///anyway.
 
-        void set(atoms& args, const bool notify = true, const bool override_readonly = false) override {
+        void set(const atoms& args, const bool notify = true, const bool override_readonly = false) override {
             if (!writable() && !override_readonly)
                 return;    // we're all done... unless this is a readonly attr that we are forcing to update
 
@@ -743,7 +727,7 @@ namespace c74::min {
         enum_map       m_enum_map;      // The enum mapping for indexed enums (as opposed to symbol enums).
         attribute_threadsafe_helper<T, threadsafety, limit_type, repetitions> m_helper{this};    // Attribute setting implementation for the specified threadsafety.
 
-        friend void attribute_threadsafe_helper_do_set<T, threadsafety, limit_type, repetitions>(attribute_threadsafe_helper<T, threadsafety, limit_type, repetitions>* helper, atoms& args);
+        friend void attribute_threadsafe_helper_do_set<T, threadsafety, limit_type, repetitions>(attribute_threadsafe_helper<T, threadsafety, limit_type, repetitions>* helper, const atoms& args);
 
 
         // Copy m_range_args to m_range when the attribute is created.
@@ -761,8 +745,8 @@ namespace c74::min {
         // Optimization for the most common case: no limiting at all.
 
         template<class U = T, typename enable_if<is_same<limit_type<U>, limit::none<U>>::value, int>::type = 0>
-        void constrain(atoms& args) const {
-            // no limiting, so do nothing
+        atoms constrain(const atoms& args) const {
+			return args;
         }
 
 
@@ -770,9 +754,9 @@ namespace c74::min {
         // Note that enums are already range-limited within the min::atom.
 
         template<class U = T, typename enable_if<!is_same<limit_type<U>, limit::none<U>>::value, int>::type = 0>
-        void constrain(atoms& args) const {
+        atoms constrain(const atoms& args) const {
             static_assert(std::is_arithmetic<T>::value, "limiting can only be applied to arithmetic types");
-            args[0] = limit_type<T>::apply(args[0], m_range[0], m_range[1]);
+            return {limit_type<T>::apply(args[0], m_range[0], m_range[1])};
         }
 
 
@@ -837,15 +821,15 @@ namespace c74::min {
     // args may be modified as a side-effect of calling this method (e.g. for range limiting)
 
     template<typename T, threadsafe threadsafety, template<typename> class limit_type, allow_repetitions repetitions>
-    void attribute_threadsafe_helper_do_set(attribute_threadsafe_helper<T, threadsafety, limit_type, repetitions>* helper, atoms& args) {
+    void attribute_threadsafe_helper_do_set(attribute_threadsafe_helper<T, threadsafety, limit_type, repetitions>* helper, const atoms& args) {
         auto& attr = *helper->m_attribute;
 
-        attr.constrain(args);
+        const auto constrained_args = attr.constrain(args);
 
         if (attr.m_setter)
-            attr.m_value = from_atoms<T>(attr.m_setter(args, -1));
+            attr.m_value = from_atoms<T>(attr.m_setter(constrained_args, -1));
         else
-            attr.assign(args);
+            attr.assign(constrained_args);
     }
 
 
@@ -856,14 +840,14 @@ namespace c74::min {
 
     template<typename T, template<typename> class limit_type, allow_repetitions repetitions>
     class attribute_threadsafe_helper<T, threadsafe::yes, limit_type, repetitions> {
-        friend void attribute_threadsafe_helper_do_set<T, threadsafe::yes, limit_type>(attribute_threadsafe_helper<T, threadsafe::yes, limit_type, repetitions>* helper, atoms& args);
+        friend void attribute_threadsafe_helper_do_set<T, threadsafe::yes, limit_type>(attribute_threadsafe_helper<T, threadsafe::yes, limit_type, repetitions>* helper, const atoms& args);
 
     public:
         explicit attribute_threadsafe_helper(attribute<T, threadsafe::yes, limit_type, repetitions>* an_attribute)
         : m_attribute(an_attribute)
         {}
 
-        void set(atoms& args) {
+        void set(const atoms& args) {
             attribute_threadsafe_helper_do_set(this, args);
         }
 
@@ -888,7 +872,7 @@ namespace c74::min {
 
     template<typename T, template<typename> class limit_type, allow_repetitions repetitions>
     class attribute_threadsafe_helper<T, threadsafe::no, limit_type, repetitions> {
-        friend void attribute_threadsafe_helper_do_set<T, threadsafe::no, limit_type>(attribute_threadsafe_helper<T, threadsafe::no, limit_type, repetitions>* helper, atoms& args);
+        friend void attribute_threadsafe_helper_do_set<T, threadsafe::no, limit_type>(attribute_threadsafe_helper<T, threadsafe::no, limit_type, repetitions>* helper, const atoms& args);
         friend void attribute_threadsafe_helper_qfn<T, threadsafe::no, limit_type, repetitions>(attribute_threadsafe_helper<T, threadsafe::no, limit_type, repetitions>* helper);
 
     public:
@@ -901,7 +885,7 @@ namespace c74::min {
             max::qelem_free(m_qelem);
         }
 
-        void set(atoms& args) {
+        void set(const atoms& args) {
             if (max::systhread_ismainthread())
                 attribute_threadsafe_helper_do_set(this, args);
             else {
@@ -923,7 +907,7 @@ namespace c74::min {
 
     template<typename T, template<typename> class limit_type, allow_repetitions repetitions>
     class attribute_threadsafe_helper<T, threadsafe::undefined, limit_type, repetitions> {
-        friend void attribute_threadsafe_helper_do_set<T, threadsafe::undefined, limit_type, repetitions>(attribute_threadsafe_helper<T, threadsafe::undefined, limit_type, repetitions>* helper, atoms& args);
+        friend void attribute_threadsafe_helper_do_set<T, threadsafe::undefined, limit_type, repetitions>(attribute_threadsafe_helper<T, threadsafe::undefined, limit_type, repetitions>* helper, const atoms& args);
         friend void attribute_threadsafe_helper_qfn<T, threadsafe::undefined, limit_type, repetitions>(attribute_threadsafe_helper<T, threadsafe::undefined, limit_type, repetitions>* helper);
 
     public:
@@ -936,7 +920,7 @@ namespace c74::min {
             max::qelem_free(m_qelem);
         }
 
-        void set(atoms& args) {
+        void set(const atoms& args) {
             if (m_attribute->owner().is_assumed_threadsafe() || max::systhread_ismainthread())
                 attribute_threadsafe_helper_do_set(this, args);
             else {

--- a/include/c74_min_attribute.h
+++ b/include/c74_min_attribute.h
@@ -502,6 +502,12 @@ namespace c74::min {
             return m_range;
         }
 
+        void set_range(const std::vector<T>& range) {
+            m_range = range;
+            auto value = static_cast<atoms>(*this);
+            set(value);
+        }
+
 
         // DO NOT USE
         // This is an internal method used to fetch the range in string format when creating the peer Max attribute.

--- a/include/c74_min_limit.h
+++ b/include/c74_min_limit.h
@@ -177,7 +177,8 @@ namespace c74::min {
 
     template<class T>
     static T scale(const T value, const T in_low, const T in_high, const T out_low, const T out_high) {
-        const auto in_scale = 1.0 / static_cast<number>(in_high - in_low);
+        const auto in_diff = static_cast<number>(in_high - in_low);
+        const auto in_scale = (in_diff != 0.0) ? (1.0 / in_diff) : 1.0;
         const auto out_diff = out_high - out_low;
         const auto normalized = static_cast<T>((value - in_low) * in_scale);
         return static_cast<T>((normalized * out_diff) + out_low);

--- a/include/c74_min_limit.h
+++ b/include/c74_min_limit.h
@@ -177,11 +177,10 @@ namespace c74::min {
 
     template<class T>
     static T scale(const T value, const T in_low, const T in_high, const T out_low, const T out_high) {
-        number in_scale = 1 / (in_high - in_low);
-        number out_diff = out_high - out_low;
-        T out = static_cast<T>((value - in_low) * in_scale);
-        out = static_cast<T>((out * out_diff) + out_low);
-        return out;
+        const auto in_scale = 1.0 / static_cast<number>(in_high - in_low);
+        const auto out_diff = out_high - out_low;
+        const auto normalized = static_cast<T>((value - in_low) * in_scale);
+        return static_cast<T>((normalized * out_diff) + out_low);
     }
 
 

--- a/test/limit.cpp
+++ b/test/limit.cpp
@@ -149,6 +149,9 @@ TEST_CASE( "scaling", "[limits]" ) {
     REQUIRE( scale(2.0, 0.0, 1.0, 0.0, 127.0) == 254.0);
     REQUIRE( scale(-1.0, 0.0, 1.0, 0.0, 127.0) == -127.0);
 
+    REQUIRE(scale(1.0, 1.0, 1.0, 0.0, 127.0) == 0.0);
+    REQUIRE(scale(0.0, 0.0, 0.0, 0.0, 127.0) == 0.0);
+
     // the same but with integers
 
     REQUIRE( scale(0, 0, 1, 0, 127) == 0);

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -6,7 +6,7 @@ using namespace c74::min;
 
 class TestObject : public object<TestObject> {};
 
-TEST_CASE("Attribute ranges") {
+TEST_CASE("Attribute - ranges", "[attribute]") {
 	TestObject my_object;
 	attribute<number, threadsafe::no, limit::clamp> my_attr {&my_object, "My Attribute", 0.0, range {-10.0, 10.0} };
 	
@@ -15,5 +15,13 @@ TEST_CASE("Attribute ranges") {
 		my_attr = value;
 		REQUIRE(static_cast<number>(my_attr) >= -10.0);
 		REQUIRE(static_cast<number>(my_attr) <= 10.0);
+	}
+	
+	SECTION("Setting an attribute's range changes its value") {
+		const auto new_value = GENERATE(-5.0, 8.0);
+		const auto new_minimum = GENERATE(1.0, 5.0);
+		my_attr = new_value;
+		my_attr.set_range({new_minimum, 10.0});
+		REQUIRE(static_cast<number>(my_attr) == std::max(new_minimum, new_value));
 	}
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -34,10 +34,6 @@ TEST_CASE("Attribute - repetitions", "[attribute]") {
 		my_attr = 5.0;
 		my_attr.set_range({7.5, 10.0});
 
-		// EXPECTED:
-		// REQUIRE(static_cast<number>(my_attr) == 7.5);
-
-		// ACTUAL:
-		REQUIRE(static_cast<number>(my_attr) == 5.0);
+		REQUIRE(static_cast<number>(my_attr) == 7.5);
 	}
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -25,3 +25,19 @@ TEST_CASE("Attribute - ranges", "[attribute]") {
 		REQUIRE(static_cast<number>(my_attr) == std::max(new_minimum, new_value));
 	}
 }
+
+TEST_CASE("Attribute - repetitions", "[attribute]") {
+	TestObject my_object;
+	attribute<number, threadsafe::no, limit::clamp, allow_repetitions::no> my_attr {&my_object, "My Attribute", 0.0, range {-10.0, 10.0}};
+
+	SECTION("Filtering out repetitions does not filter out a value when the range has changed") {
+		my_attr = 5.0;
+		my_attr.set_range({7.5, 10.0});
+
+		// EXPECTED:
+		// REQUIRE(static_cast<number>(my_attr) == 7.5);
+
+		// ACTUAL:
+		REQUIRE(static_cast<number>(my_attr) == 5.0);
+	}
+}


### PR DESCRIPTION
The new `set_range` method updates an attribute's range and sets the attribute's value so that the new range gets applied. This new addition also exposed a bug with attributes that set `allow_repetitions::no`: the attribute's range was not taken into account while checking whether the new value was a repetition. The `Add a test that shows that ranges aren't applied correctly before filtering out repetitions` commit shows the bug.

The fix required the new args to be constrained before passing them into `compare_to_current_value`. However, the constrain method was called much later and did alter the atoms in-place. Therefore, we couldn't really use the constrain method as it was. Now, instead of altering the atoms in-place, the constrain method returns the constrained atoms. This change also allows us to make the set method's arguments const.

Finally, the `scale` function didn't work properly when the `in_low` and `out_low` arguments were equal.