### PR TITLE
consolidated bugfixes/features

### DIFF
--- a/include/c74_min_object_wrapper.h
+++ b/include/c74_min_object_wrapper.h
@@ -48,6 +48,8 @@ namespace c74::min {
             self->m_min_object.set_classname(name);
 
             self->setup();
+
+            //setup : a special method called when your instance is being instantiated
             self->m_min_object.try_call("setup");
 
             if (self->m_min_object.is_ui_class()) {

--- a/include/c74_min_object_wrapper.h
+++ b/include/c74_min_object_wrapper.h
@@ -48,6 +48,7 @@ namespace c74::min {
             self->m_min_object.set_classname(name);
 
             self->setup();
+            self->m_min_object.try_call("setup");
 
             if (self->m_min_object.is_ui_class()) {
                 max::t_dictionary* d = object_dictionaryarg(ac, av);

--- a/include/c74_min_object_wrapper.h
+++ b/include/c74_min_object_wrapper.h
@@ -309,15 +309,6 @@ namespace c74::min {
     }
 
     template<class min_class_type, class message_name_type>
-    void wrapper_method_self_ptr_long(max::t_object* o, const void* arg1, const max::t_atom_long arg2) {
-        auto  self = wrapper_find_self<min_class_type>(o);
-        auto& meth = *self->m_min_object.messages()[message_name_type::name];
-        atoms as {o, arg1, arg2};
-                                                // pass `o` which is always the correct `self` for box operations
-        meth(as);
-    }
-
-    template<class min_class_type, class message_name_type>
     void wrapper_method_getplaystate(max::t_object* o, long* play, double* pos, long* loop) {
         auto  self = wrapper_find_self<min_class_type>(o);
         auto& meth = *self->m_min_object.messages()[message_name_type::name];
@@ -517,7 +508,7 @@ namespace c74::min {
 
         for (auto& a_message : instance.messages()) {
             MIN_WRAPPER_ADDMETHOD(c, bang, zero, A_NOTHING)
-            else MIN_WRAPPER_ADDMETHOD(c, dspstate, self_ptr_long, A_CANT)
+            else MIN_WRAPPER_ADDMETHOD(c, dspstate, int, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, dblclick, zero, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, okclose, zero, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, edclose, zero, A_CANT)
@@ -810,7 +801,7 @@ namespace c74::min {
         // must happen pror to max_jit_class_wrap_standard call
         for (auto& a_message : instance->messages()) {
             MIN_WRAPPER_ADDMETHOD(c, bang, zero, A_NOTHING)
-            else MIN_WRAPPER_ADDMETHOD(c, dspstate, self_ptr_long, A_CANT)
+            else MIN_WRAPPER_ADDMETHOD(c, dspstate, int, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, dblclick, zero, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, okclose, zero, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, edclose, zero, A_CANT)

--- a/include/c74_min_object_wrapper.h
+++ b/include/c74_min_object_wrapper.h
@@ -309,6 +309,15 @@ namespace c74::min {
     }
 
     template<class min_class_type, class message_name_type>
+    void wrapper_method_self_ptr_long(max::t_object* o, const void* arg1, const max::t_atom_long arg2) {
+        auto  self = wrapper_find_self<min_class_type>(o);
+        auto& meth = *self->m_min_object.messages()[message_name_type::name];
+        atoms as {o, arg1, arg2};
+                                                // pass `o` which is always the correct `self` for box operations
+        meth(as);
+    }
+
+    template<class min_class_type, class message_name_type>
     void wrapper_method_getplaystate(max::t_object* o, long* play, double* pos, long* loop) {
         auto  self = wrapper_find_self<min_class_type>(o);
         auto& meth = *self->m_min_object.messages()[message_name_type::name];
@@ -444,6 +453,7 @@ namespace c74::min {
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(bang)
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(dblclick)
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(dictionary)
+    MIN_WRAPPER_CREATE_TYPE_FROM_STRING(dspstate)
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(edclose)
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(fileusage)
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(float)
@@ -507,6 +517,7 @@ namespace c74::min {
 
         for (auto& a_message : instance.messages()) {
             MIN_WRAPPER_ADDMETHOD(c, bang, zero, A_NOTHING)
+            else MIN_WRAPPER_ADDMETHOD(c, dspstate, self_ptr_long, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, dblclick, zero, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, okclose, zero, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, edclose, zero, A_CANT)
@@ -544,13 +555,13 @@ namespace c74::min {
             else if (a_message.first == "maxclass_setup");          // for min class construction only, do not add for exposure to max
             else if (a_message.first == "savestate")
                 max::class_addmethod(c, reinterpret_cast<max::method>(wrapper_method_savestate<min_class_type>), "appendtodictionary", max::A_CANT, 0);
-        	else {
-                if (a_message.second->type() == max::A_GIMMEBACK) {
-                    max::class_addmethod(c, reinterpret_cast<method>(wrapper_method_generic_typed<min_class_type>), 
-                        a_message.first.c_str(), a_message.second->type(), 0);
-				}
-                else {
-					max::class_addmethod(c, reinterpret_cast<method>(wrapper_method_generic<min_class_type>), 
+            else {
+              if (a_message.second->type() == max::A_GIMMEBACK) {
+                max::class_addmethod(c, reinterpret_cast<method>(wrapper_method_generic_typed<min_class_type>),
+                    a_message.first.c_str(), a_message.second->type(), 0);
+              }
+              else {
+                max::class_addmethod(c, reinterpret_cast<method>(wrapper_method_generic<min_class_type>),
                         a_message.first.c_str(), a_message.second->type(), 0);
                 }
             }
@@ -566,7 +577,7 @@ namespace c74::min {
         for (auto& an_attribute : instance.attributes()) {
             std::string     attr_name  { an_attribute.first };
             attribute_base& attr       { *an_attribute.second };
- 
+
             if (attr.visible() == visibility::disable)
                 continue;
 
@@ -585,7 +596,7 @@ namespace c74::min {
                 max::object_parameter_color_get(nullptr, attr.live_color_mapping(), &current_color);
 
                 const auto str = std::to_string(current_color.red) + " " + std::to_string(current_color.green) + " "
-					+ std::to_string(current_color.blue) + " " + std::to_string(current_color.alpha);
+                  + std::to_string(current_color.blue) + " " + std::to_string(current_color.alpha);
 
                 CLASS_ATTR_DEFAULTNAME(c, attr_name.c_str(), 0, str.c_str());
                 max::class_parameter_register_default_color(c, symbol(attr_name), attr.live_color_mapping());
@@ -799,6 +810,7 @@ namespace c74::min {
         // must happen pror to max_jit_class_wrap_standard call
         for (auto& a_message : instance->messages()) {
             MIN_WRAPPER_ADDMETHOD(c, bang, zero, A_NOTHING)
+            else MIN_WRAPPER_ADDMETHOD(c, dspstate, self_ptr_long, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, dblclick, zero, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, okclose, zero, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, edclose, zero, A_CANT)

--- a/include/c74_min_object_wrapper.h
+++ b/include/c74_min_object_wrapper.h
@@ -508,8 +508,8 @@ namespace c74::min {
 
         for (auto& a_message : instance.messages()) {
             MIN_WRAPPER_ADDMETHOD(c, bang, zero, A_NOTHING)
-            else MIN_WRAPPER_ADDMETHOD(c, dspstate, int, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, dblclick, zero, A_CANT)
+            else MIN_WRAPPER_ADDMETHOD(c, dspstate, int, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, okclose, zero, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, edclose, zero, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, loadbang, zero, A_CANT)
@@ -801,8 +801,8 @@ namespace c74::min {
         // must happen pror to max_jit_class_wrap_standard call
         for (auto& a_message : instance->messages()) {
             MIN_WRAPPER_ADDMETHOD(c, bang, zero, A_NOTHING)
-            else MIN_WRAPPER_ADDMETHOD(c, dspstate, int, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, dblclick, zero, A_CANT)
+            else MIN_WRAPPER_ADDMETHOD(c, dspstate, int, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, okclose, zero, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, edclose, zero, A_CANT)
             else MIN_WRAPPER_ADDMETHOD(c, loadbang, zero, A_CANT)

--- a/include/c74_min_operator_vector.h
+++ b/include/c74_min_operator_vector.h
@@ -308,8 +308,10 @@ namespace c74::min {
 
     template<class min_class_type>
     void min_dsp64_io(minwrap<min_class_type>* self, const short* count) {
-        int i = 0;
+        if (count == nullptr)
+            return;
 
+        int i = 0;
         while (i < self->m_min_object.inlets().size()) {
             self->m_min_object.inlets()[i]->update_signal_connection(count[i] != 0);
             ++i;

--- a/include/c74_min_outlet.h
+++ b/include/c74_min_outlet.h
@@ -98,7 +98,7 @@ namespace c74::min {
         {}
 
         void callback() {
-            outlet_do_send(m_value);
+            outlet_do_send(this->m_baton, m_value);
             m_set = false;
         }
 


### PR DESCRIPTION
* allow for min classes to have multiple buffers
  * before this work the notifications methods stomped on each other
* call the instance `setup` method, just wasn't called before
* add `dspstate` method
* fix queued outlet, actually send to the outlet by index (baton)