### PR TITLE
better autogeneration of reference file

### DIFF
--- a/include/c74_min_attribute.h
+++ b/include/c74_min_attribute.h
@@ -206,6 +206,13 @@ namespace c74::min {
         symbol name() const {
             return m_name;
         }
+        
+        /// Determine the size of the attribute
+        /// @return the size of the attribute
+        
+        size_t size() const {
+            return m_size;
+        }
 
 
         /// Is the attribute writable (meaning settable)?

--- a/include/c74_min_object_components.h
+++ b/include/c74_min_object_components.h
@@ -175,12 +175,24 @@ namespace c74::min {
         auto inlets() -> std::vector<inlet_base*>& {
             return m_inlets;
         }
+       
+    	/// Get a reference to this object's inlets.
+        /// @return	A reference to this object's inlets.
+        auto inlets() const -> const std::vector<inlet_base*>& {
+            return m_inlets;
+        }
 
 
         /// Get a reference to this object's outlets.
         /// @return	A reference to this object's outlets.
 
         auto outlets() -> std::vector<outlet_base*>& {
+            return m_outlets;
+        }
+        
+        /// Get a reference to this object's outlets.
+        /// @return	A reference to this object's outlets.
+        auto outlets() const -> const std::vector<outlet_base*>& {
             return m_outlets;
         }
 


### PR DESCRIPTION
these just add to autogeneration that make it contain some of the other information/fields used in standard max reference
adds MIN_DISCUSSION to add an optional discssion section
documents list of inlets and outlets. these exist in currernt max documentation but don't seem to be used.
indicates forrect size of attributes (e.g. 2 symbols)
indicates default value for attributes
lists options for enumvals as seen in max reference documents.