### PR TITLE
Add method to register an existing dictionary

### DIFF
--- a/include/c74_min_dictionary.h
+++ b/include/c74_min_dictionary.h
@@ -136,6 +136,17 @@ namespace c74::min {
         }
 
 
+		/// Register an existing dictionary
+		/// @param name   name to register the dictionary under
+		void register_as(const symbol name) {
+			auto d_name = max::dictobj_namefromptr(m_instance);
+			if (!d_name && m_instance != nullptr) {
+				max::t_symbol* s = name;
+				max::dictobj_register(m_instance, &s);
+			}
+		}
+
+
     private:
         max::t_dictionary* m_instance       { nullptr };
         bool               m_has_ownership  { true };

--- a/include/c74_min_dictionary.h
+++ b/include/c74_min_dictionary.h
@@ -139,10 +139,9 @@ namespace c74::min {
 		/// Register an existing dictionary
 		/// @param name   name to register the dictionary under
 		void register_as(const symbol name) {
-			auto d_name = max::dictobj_namefromptr(m_instance);
-			if (!d_name && m_instance != nullptr) {
+			if (m_instance != nullptr) {
 				max::t_symbol* s = name;
-				max::dictobj_register(m_instance, &s);
+				m_instance = max::dictobj_register(m_instance, &s);
 			}
 		}
 


### PR DESCRIPTION
Currently I don't believe there's a way to register a dictionary that's already been created without copying the whole thing. (e.g. https://cycling74.com/forums/accessing-nested-dictionaries-in-min/)

Adding a `register_as(const symbol name)` method would be one way to expose such functionality.