### PR TITLE
define cleanup and remove ambiguties

### DIFF
--- a/include/c74_min_api.h
+++ b/include/c74_min_api.h
@@ -22,12 +22,12 @@
 #include <unordered_map>
 #include <utility>
 
-#ifdef MAC_VERSION
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-variable"
 #endif
 #include "readerwriterqueue/readerwriterqueue.h"
-#ifdef MAC_VERSION
+#ifdef __clang__
 #pragma clang diagnostic pop
 #endif
 

--- a/include/c74_min_atom.h
+++ b/include/c74_min_atom.h
@@ -52,16 +52,12 @@ namespace c74::min {
             *this = *init;
             return *this;
         }
-      
-        atom& operator=(max::t_atom_long value) {
-            max::atom_setlong(this, value);
-            return *this;
-        }
 
-        atom& operator=(int32_t value) {
-            max::atom_setlong(this, static_cast<max::t_atom_long>(value));
+        template<typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
+          atom& operator=(T value) {
+            max::atom_setlong(this, static_cast<t_atom_long>(value));
             return *this;
-        }
+          }     
 
         atom& operator=(double value) {
             max::atom_setfloat(this, value);

--- a/include/c74_min_atom.h
+++ b/include/c74_min_atom.h
@@ -26,7 +26,7 @@ namespace c74::min {
         /// constructor with enum initializer
         template<class T, typename enable_if<std::is_enum<T>::value, int>::type = 0>
         atom(const T initial_value) {
-            *this = static_cast<int>(initial_value);
+            *this = static_cast<max::t_atom_long>(initial_value);
         }
 
         atom(const event& e) {
@@ -53,28 +53,18 @@ namespace c74::min {
             return *this;
         }
       
-        atom& operator=(long value) {
-            max::atom_setlong(this, max::t_atom_long(value));
+        atom& operator=(max::t_atom_long value) {
+            max::atom_setlong(this, value);
             return *this;
         }
 
-        atom& operator=(const int64_t value) {
-            max::atom_setlong(this, max::t_atom_long(value));
+        atom& operator=(int32_t value) {
+            max::atom_setlong(this, static_cast<max::t_atom_long>(value));
             return *this;
         }
 
-        atom& operator=(const int32_t value) {
-            max::atom_setlong(this, max::t_atom_long(value));
-            return *this;
-        }
-
-        atom& operator=(const bool value) {
-            max::atom_setlong(this, max::t_atom_long(value));
-            return *this;
-        }
-
-        atom& operator=(const double value) {
-            max::atom_setfloat(this, double(value));
+        atom& operator=(double value) {
+            max::atom_setfloat(this, value);
             return *this;
         }
 

--- a/include/c74_min_atom.h
+++ b/include/c74_min_atom.h
@@ -53,12 +53,27 @@ namespace c74::min {
             return *this;
         }
       
-        atom& operator=(max::t_atom_long value) {
-            max::atom_setlong(this, value);
+        atom& operator=(long value) {
+            max::atom_setlong(this, max::t_atom_long(value));
             return *this;
         }
 
-        atom& operator=(double value) {
+        atom& operator=(const int64_t value) {
+            max::atom_setlong(this, max::t_atom_long(value));
+            return *this;
+        }
+
+        atom& operator=(const int32_t value) {
+            max::atom_setlong(this, max::t_atom_long(value));
+            return *this;
+        }
+
+        atom& operator=(const bool value) {
+            max::atom_setlong(this, max::t_atom_long(value));
+            return *this;
+        }
+
+        atom& operator=(const double value) {
             max::atom_setfloat(this, double(value));
             return *this;
         }

--- a/include/c74_min_atom.h
+++ b/include/c74_min_atom.h
@@ -53,27 +53,12 @@ namespace c74::min {
             return *this;
         }
       
-        atom& operator=(long value) {
-            max::atom_setlong(this, max::t_atom_long(value));
+        atom& operator=(max::t_atom_long value) {
+            max::atom_setlong(this, value);
             return *this;
         }
 
-        atom& operator=(const int64_t value) {
-            max::atom_setlong(this, max::t_atom_long(value));
-            return *this;
-        }
-
-        atom& operator=(const int32_t value) {
-            max::atom_setlong(this, max::t_atom_long(value));
-            return *this;
-        }
-
-        atom& operator=(const bool value) {
-            max::atom_setlong(this, max::t_atom_long(value));
-            return *this;
-        }
-
-        atom& operator=(const double value) {
+        atom& operator=(double value) {
             max::atom_setfloat(this, double(value));
             return *this;
         }

--- a/include/c74_min_dictionary.h
+++ b/include/c74_min_dictionary.h
@@ -136,6 +136,16 @@ namespace c74::min {
         }
 
 
+		/// Register an existing dictionary
+		/// @param name   name to register the dictionary under
+		void register_as(const symbol name) {
+			if (m_instance != nullptr) {
+				max::t_symbol* s = name;
+				m_instance = max::dictobj_register(m_instance, &s);
+			}
+		}
+
+
     private:
         max::t_dictionary* m_instance       { nullptr };
         bool               m_has_ownership  { true };

--- a/include/c74_min_object_components.h
+++ b/include/c74_min_object_components.h
@@ -251,7 +251,7 @@ namespace c74::min {
         }
 
 
-        patcher patcher() {
+        min::patcher patcher() {
             max::t_object* p {};
 
             auto err = max::object_obex_lookup(maxobj(), k_sym__pound_p, &p);
@@ -261,7 +261,7 @@ namespace c74::min {
         }
 
 
-        box box() {
+        min::box box() {
             max::t_object* b {};
 
             auto err = max::object_obex_lookup(maxobj(), k_sym__pound_b, &b);


### PR DESCRIPTION
* use `__clang__` where pragmas are clang specific
* `int64_t` == `long` on some platforms.. replace all the integral atom assignment operators with a template method
* fix box/patcher ambiguity