### PR TITLE
Mouse wheel

### DIFF
--- a/include/c74_min_event.h
+++ b/include/c74_min_event.h
@@ -27,12 +27,11 @@ namespace c74::min {
                 auto* e = static_cast<event*>( static_cast<void*>(args[0]) );
                 *this = *e;
             }
-			else if (args.size() == 3)
-			{
-				// a triplet indicates we are being passed a pointer to an event containing additional mousewheel deltas
-				auto* e = static_cast<event*>( static_cast<void*>(args[0]) );
-				e->m_wheel_delta_x = args[1];
-				e->m_wheel_delta_y = args[2];
+            else if (args.size() == 3){
+                // a triplet indicates we are being passed a pointer to an event containing additional mousewheel deltas
+                auto* e = static_cast<event*>( static_cast<void*>(args[0]) );
+                e->m_wheel_delta_x = args[1];
+                e->m_wheel_delta_y = args[2];
                 *this = *e;
 			}
             else if (args.size() != 5) {
@@ -130,13 +129,13 @@ namespace c74::min {
 			return m_pen_tilt_y;   
         }
 
-		auto wheel_delta_x() const {
-			return m_wheel_delta_x;
-		}
+        auto wheel_delta_x() const {
+            return m_wheel_delta_x;
+        }
 
-		auto wheel_delta_y() const {
-			return m_wheel_delta_y;
-		}
+        auto wheel_delta_y() const {
+            return m_wheel_delta_y;
+        }
 
     private:
         max::t_object*  m_self;
@@ -151,8 +150,8 @@ namespace c74::min {
 		number          m_pen_rotation {};
 		number          m_pen_tilt_x {};
 		number          m_pen_tilt_y {};
-		number			m_wheel_delta_x {};
-		number			m_wheel_delta_y {};
+		number          m_wheel_delta_x {};
+		number          m_wheel_delta_y {};
 	};
 
 }    // namespace c74::min

--- a/include/c74_min_event.h
+++ b/include/c74_min_event.h
@@ -27,6 +27,14 @@ namespace c74::min {
                 auto* e = static_cast<event*>( static_cast<void*>(args[0]) );
                 *this = *e;
             }
+			else if (args.size() == 3)
+			{
+				// a triplet indicates we are being passed a pointer to an event containing additional mousewheel deltas
+				auto* e = static_cast<event*>( static_cast<void*>(args[0]) );
+				e->m_wheel_delta_x = args[1];
+				e->m_wheel_delta_y = args[2];
+                *this = *e;
+			}
             else if (args.size() != 5) {
                 error("incorrect number of arguments for notification");
             }
@@ -122,6 +130,14 @@ namespace c74::min {
 			return m_pen_tilt_y;   
         }
 
+		auto wheel_delta_x() const {
+			return m_wheel_delta_x;
+		}
+
+		auto wheel_delta_y() const {
+			return m_wheel_delta_y;
+		}
+
     private:
         max::t_object*  m_self;
         ui::target      m_target;
@@ -135,7 +151,8 @@ namespace c74::min {
 		number          m_pen_rotation {};
 		number          m_pen_tilt_x {};
 		number          m_pen_tilt_y {};
-    };
-
+		number			m_wheel_delta_x {};
+		number			m_wheel_delta_y {};
+	};
 
 }    // namespace c74::min

--- a/include/c74_min_message.h
+++ b/include/c74_min_message.h
@@ -53,7 +53,8 @@ namespace c74::min {
                 || a_name == "notify" || a_name == "okclose" || a_name == "oksize" || a_name == "paint"
                 || a_name == "patchlineupdate" || a_name == "savestate" || a_name == "setup"
                 || a_name == "mouseenter" || a_name == "mouseleave" || a_name == "mousedown" || a_name == "mouseup" || a_name == "mousemove"
-                || a_name == "mousedragdelta" || a_name == "mousedoubleclick"
+                || a_name == "mousedragdelta" || a_name == "mousedoubleclick" 
+				|| a_name == "mousewheel"
                 || a_name == "focusgained" || a_name == "focuslost"
                 || a_name == "loadbang")
             {

--- a/include/c74_min_message.h
+++ b/include/c74_min_message.h
@@ -54,7 +54,7 @@ namespace c74::min {
                 || a_name == "patchlineupdate" || a_name == "savestate" || a_name == "setup"
                 || a_name == "mouseenter" || a_name == "mouseleave" || a_name == "mousedown" || a_name == "mouseup" || a_name == "mousemove"
                 || a_name == "mousedragdelta" || a_name == "mousedoubleclick" 
-				|| a_name == "mousewheel"
+                || a_name == "mousewheel"
                 || a_name == "focusgained" || a_name == "focuslost"
                 || a_name == "loadbang")
             {

--- a/include/c74_min_object_wrapper.h
+++ b/include/c74_min_object_wrapper.h
@@ -236,23 +236,23 @@ namespace c74::min {
         meth(as);
     }
 
-	template<class min_class_type, class message_name_type>
-	void wrapper_method_mousewheel(max::t_object *o, max::t_object *a_patcherview, max::t_pt position, long modifiers, double delta_x, double delta_y) {
-		auto  self = wrapper_find_self<min_class_type>(o);
+    template<class min_class_type, class message_name_type>
+    void wrapper_method_mousewheel(max::t_object *o, max::t_object *a_patcherview, max::t_pt position, long modifiers, double delta_x, double delta_y) {
+        auto  self = wrapper_find_self<min_class_type>(o);
         auto& meth = *self->m_min_object.messages()[message_name_type::name];
         max::t_mouseevent an_event {};
-
+        
         an_event.type = max::eMouseEvent;
         an_event.index = 0; // zero-based or one based ???
         an_event.position = position;
         an_event.modifiers = static_cast<max::t_modifiers>(modifiers);
-
-		event e { o, a_patcherview, an_event };
-		atom deltaX { delta_x };
-		atom deltaY { delta_y };
-		atoms as { e, deltaX, deltaY };
-		meth(as);
-	}
+        
+        event e { o, a_patcherview, an_event };
+        atom deltaX { delta_x };
+        atom deltaY { delta_y };
+        atoms as { e, deltaX, deltaY };
+        meth(as);
+    }
 
 
     template<class min_class_type, class message_name_type>
@@ -489,7 +489,7 @@ namespace c74::min {
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(mt_mousedrag)
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(mousedragdelta)
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(mousedoubleclick)
-	MIN_WRAPPER_CREATE_TYPE_FROM_STRING(mousewheel)
+    MIN_WRAPPER_CREATE_TYPE_FROM_STRING(mousewheel)
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(notify)
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(okclose)
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(oksize)
@@ -568,8 +568,8 @@ namespace c74::min {
             else if (a_message.first == "maxclass_setup");          // for min class construction only, do not add for exposure to max
             else if (a_message.first == "savestate")
                 max::class_addmethod(c, reinterpret_cast<max::method>(wrapper_method_savestate<min_class_type>), "appendtodictionary", max::A_CANT, 0);
-			else if (a_message.first == "mousewheel")
-				max::class_addmethod(c, reinterpret_cast<max::method>(wrapper_method_mousewheel<min_class_type, wrapper_message_name_mousewheel>), "mousewheel", max::A_CANT, 0);
+            else if (a_message.first == "mousewheel")
+                max::class_addmethod(c, reinterpret_cast<max::method>(wrapper_method_mousewheel<min_class_type, wrapper_message_name_mousewheel>), "mousewheel", max::A_CANT, 0);
 
             else {
               if (a_message.second->type() == max::A_GIMMEBACK) {
@@ -864,8 +864,8 @@ namespace c74::min {
             else if (a_message.first == "mop_setup");         // for min class construction only, do not add for exposure to max
             else if (a_message.first == "maxob_setup");       // for min class construction only, do not add for exposure to max
             else if (a_message.first == "setup");             // for min class construction only, do not add for exposure to max
-			else if (a_message.first == "mousewheel")
-				max::class_addmethod(c, reinterpret_cast<max::method>(wrapper_method_mousewheel<min_class_type, wrapper_message_name_mousewheel>), "mousewheel", max::A_CANT, 0);
+            else if (a_message.first == "mousewheel")
+                max::class_addmethod(c, reinterpret_cast<max::method>(wrapper_method_mousewheel<min_class_type, wrapper_message_name_mousewheel>), "mousewheel", max::A_CANT, 0);
             else {
                 if (a_message.second->type() == max::A_GIMMEBACK) {
                     // add handlers for gimmeback messages, allowing for return values in JS and max wrapper dumpout

--- a/include/c74_min_object_wrapper.h
+++ b/include/c74_min_object_wrapper.h
@@ -236,6 +236,24 @@ namespace c74::min {
         meth(as);
     }
 
+	template<class min_class_type, class message_name_type>
+	void wrapper_method_mousewheel(max::t_object *o, max::t_object *a_patcherview, max::t_pt position, long modifiers, double delta_x, double delta_y) {
+		auto  self = wrapper_find_self<min_class_type>(o);
+        auto& meth = *self->m_min_object.messages()[message_name_type::name];
+        max::t_mouseevent an_event {};
+
+        an_event.type = max::eMouseEvent;
+        an_event.index = 0; // zero-based or one based ???
+        an_event.position = position;
+        an_event.modifiers = static_cast<max::t_modifiers>(modifiers);
+
+		event e { o, a_patcherview, an_event };
+		atom deltaX { delta_x };
+		atom deltaY { delta_y };
+		atoms as { e, deltaX, deltaY };
+		meth(as);
+	}
+
 
     template<class min_class_type, class message_name_type>
     void wrapper_method_multitouch(max::t_object* o, max::t_object* a_patcherview, const max::t_mouseevent* an_event) {
@@ -471,6 +489,7 @@ namespace c74::min {
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(mt_mousedrag)
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(mousedragdelta)
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(mousedoubleclick)
+	MIN_WRAPPER_CREATE_TYPE_FROM_STRING(mousewheel)
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(notify)
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(okclose)
     MIN_WRAPPER_CREATE_TYPE_FROM_STRING(oksize)
@@ -549,6 +568,9 @@ namespace c74::min {
             else if (a_message.first == "maxclass_setup");          // for min class construction only, do not add for exposure to max
             else if (a_message.first == "savestate")
                 max::class_addmethod(c, reinterpret_cast<max::method>(wrapper_method_savestate<min_class_type>), "appendtodictionary", max::A_CANT, 0);
+			else if (a_message.first == "mousewheel")
+				max::class_addmethod(c, reinterpret_cast<max::method>(wrapper_method_mousewheel<min_class_type, wrapper_message_name_mousewheel>), "mousewheel", max::A_CANT, 0);
+
             else {
               if (a_message.second->type() == max::A_GIMMEBACK) {
                 max::class_addmethod(c, reinterpret_cast<method>(wrapper_method_generic_typed<min_class_type>),
@@ -842,6 +864,8 @@ namespace c74::min {
             else if (a_message.first == "mop_setup");         // for min class construction only, do not add for exposure to max
             else if (a_message.first == "maxob_setup");       // for min class construction only, do not add for exposure to max
             else if (a_message.first == "setup");             // for min class construction only, do not add for exposure to max
+			else if (a_message.first == "mousewheel")
+				max::class_addmethod(c, reinterpret_cast<max::method>(wrapper_method_mousewheel<min_class_type, wrapper_message_name_mousewheel>), "mousewheel", max::A_CANT, 0);
             else {
                 if (a_message.second->type() == max::A_GIMMEBACK) {
                     // add handlers for gimmeback messages, allowing for return values in JS and max wrapper dumpout


### PR DESCRIPTION
Added min wrapping for Mouse Scroll events. 

With this commit mouse scroll messages can now be received in a min external via min::message like so:

    c74::min::message<> mousewheel { this, "mousewheel",
        MIN_FUNCTION {
                 c74::min::event   e { args };
                 const auto deltaX = e.wheel_delta_x ();
                 const auto deltaY = e.wheel_delta_y ();
                 return {};
        }
    };