### PR TITLE
`vector_size()` should take and return an int

### DIFF
--- a/include/c74_min_operator_mc.h
+++ b/include/c74_min_operator_mc.h
@@ -57,7 +57,7 @@ namespace c74::min {
         /// It is called internally any time the dsp chain containing your object is compiled.
         /// @param	a_vector_size	A new vector size with which your object will be updated.
 
-        void vector_size(const double a_vector_size) {
+        void vector_size(const int a_vector_size) {
             m_vector_size = a_vector_size;
         }
 
@@ -65,7 +65,7 @@ namespace c74::min {
         /// Return the current vector size for this object's signal chain.
         /// @return	The vector size in samples.
 
-        double vector_size() const {
+        int vector_size() const {
             return m_vector_size;
         }
 

--- a/include/c74_min_operator_sample.h
+++ b/include/c74_min_operator_sample.h
@@ -81,7 +81,7 @@ namespace c74::min {
         /// It is called internally any time the dsp chain containing your object is compiled.
         /// @param	a_vector_size	A new vector size with which your object will be updated.
 
-        void vector_size(const double a_vector_size) {
+        void vector_size(const int a_vector_size) {
             m_vector_size = a_vector_size;
         }
 
@@ -89,7 +89,7 @@ namespace c74::min {
         /// Return the current vector size for this object's signal chain.
         /// @return	The vector size in samples.
 
-        double vector_size() const {
+        int vector_size() const {
             return m_vector_size;
         }
 

--- a/include/c74_min_operator_vector.h
+++ b/include/c74_min_operator_vector.h
@@ -204,7 +204,7 @@ namespace c74::min {
         /// It is called internally any time the dsp chain containing your object is compiled.
         /// @param	a_vector_size	A new vector size with which your object will be updated.
 
-        void vector_size(const double a_vector_size) {
+        void vector_size(const int a_vector_size) {
             m_vector_size = a_vector_size;
         }
 
@@ -212,7 +212,7 @@ namespace c74::min {
         /// Return the current vector size for this object's signal chain.
         /// @return	The vector size in samples.
 
-        double vector_size() const {
+        int vector_size() const {
             return m_vector_size;
         }
 


### PR DESCRIPTION
This matches the type of `m_vector_size` as well as the type returned by `c74::max::sys_getblksize()`.