### PR TITLE
Fix missing #include for clamp in file c74_min_limit.h

### DIFF
--- a/include/c74_min_limit.h
+++ b/include/c74_min_limit.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 namespace c74::min {
 
 


### PR DESCRIPTION
when compiling on homebrew llvm 16.0.2 on macOS there is an include for std::clamp for the algorithm missing:
#include <algorithm>