### PR TITLE
added set_long, set_float and set_atoms methods to min::instance class

### DIFF
--- a/include/c74_min_patcher.h
+++ b/include/c74_min_patcher.h
@@ -133,6 +133,19 @@ namespace c74::min {
             max::object_attr_setchar(m_instance, attribute_name, value);
         }
 
+        void set_long(const symbol attribute_name, const long value) {
+            max::object_attr_setlong(m_instance, attribute_name, value);
+        }
+        
+        void set_float(const symbol attribute_name, const float value) {
+            max::object_attr_setfloat(m_instance, attribute_name, value);
+        }
+
+        void set_atoms(const symbol attribute_name, atoms values) {
+            if (values.size () > 0)
+                max::object_attr_setvalueof(m_instance, attribute_name, values.size (), (max::atom*)&values[0]);
+        }
+
         template<typename T>
         T get(const symbol attribute_name) const {
             long argc {};


### PR DESCRIPTION
I added these 3 setters, because I'm currently working on an external that exposes as parameter to Ableton Live via the getvalueof/setvalueof interface. To set attributes on this exposed parameter, i have to edit attributes on the object using 

max::object_attr_setlong, max::object_attr_setfloat and max::object_attr_setvalueof

so I wrapped those in the same place where object_attr_setchar and object_attr_setsym are wrapped. I'm not sure if there's a better way to overload the existing set functions for a more consistent call style, but when I tried just overloading them everything became ambigous obviously. 

Here's a simplified snippet from my code where I use these new functions on a min::box that exposes the getvalueof/setvalueof interface: 

                
```c++
    min::box box;
    MyParamWrapper paramProp;
    
    box.set ("parameter_enable", 1);
    box.set ("presentation", 1);
    box.set ("_parameter_initial_enable", 1);
    box.set_long ("_parameter_type", getMaxParameterType () ); 
    box.set_float ("_parameter_initial", paramProp.getInitialValue ());       

    const auto paramId = paramProp.getName ().toRawUTF8();
    const auto displayName = paramProp.getDisplayName ().toRawUTF8();
    const auto range = paramProp.getRange ();

    box.set ("_parameter_longname", displayName);
    box.set ("_parameter_shortname", displayName);
    box.set_long ("_parameter_steps", paramProp.getNumSteps ());
    box.set ("_parameter_unitstyle", 9 /*custom*/);
    box.set ("_parameter_units", paramProp.getUnit ().toRawUTF8());

    box.set ("_parameter_invisible", paramProp.hasYumMetaData () ? 0 : 1);

    if (paramProp.isEnum ())
    {
        min::atoms enumAtoms;
        for (auto enumVal : paramProp.getEnumValues ())
            enumAtoms.push_back (min::atom { enumVal.toRawUTF8() });
        box.set_atoms ("_parameter_range", enumAtoms);
    }
    else
    {
        box.set_atoms ("_parameter_range", min::atoms { min::atom { range.getStart () }, min::atom { range.getEnd () } });
    }
``` 