### PR TITLE
#203 adding operator 'vector<symbol>() const' and 'operator vector<number>() const' to class atom_reference

### DIFF
--- a/include/c74_min_atom.h
+++ b/include/c74_min_atom.h
@@ -411,7 +411,7 @@ class atom_reference
     {
         vector<symbol> v(m_ac);
         for (auto i = 0; i < m_ac; ++i) {
-            v[i] = static_cast<number>(atom_getsym(m_av + i));
+            v[i] = static_cast<symbol>(atom_getsym(m_av + i));
         }
         return v;
     }

--- a/include/c74_min_atom.h
+++ b/include/c74_min_atom.h
@@ -397,7 +397,7 @@ class atom_reference
         }
         return v;
     }
-    
+
     operator vector<number>() const
     {
         vector<number> v(m_ac);
@@ -406,7 +406,7 @@ class atom_reference
         }
         return v;
     }
-    
+
     operator vector<symbol>() const
     {
         vector<symbol> v(m_ac);

--- a/include/c74_min_atom.h
+++ b/include/c74_min_atom.h
@@ -397,6 +397,24 @@ class atom_reference
         }
         return v;
     }
+    
+    operator vector<number>() const
+    {
+        vector<number> v(m_ac);
+        for (auto i = 0; i < m_ac; ++i) {
+            v[i] = static_cast<number>(atom_getfloat(m_av + i));
+        }
+        return v;
+    }
+    
+    operator vector<symbol>() const
+    {
+        vector<symbol> v(m_ac);
+        for (auto i = 0; i < m_ac; ++i) {
+            v[i] = static_cast<number>(atom_getsym(m_av + i));
+        }
+        return v;
+    }
 
   private:
     long m_ac;


### PR DESCRIPTION
issue #203 #203 adding operator 'vector<symbol>() const' and 'operator vector<number>() const' to class atom_reference