### PR TITLE
Update c74_min_object_wrapper.h to create a post_attribute_setup message.

### DIFF
--- a/include/c74_min_object_wrapper.h
+++ b/include/c74_min_object_wrapper.h
@@ -54,12 +54,14 @@ minwrap<min_class_type>* wrapper_new(const max::t_symbol* name, const long ac, c
             max::t_dictionary* d = object_dictionaryarg(ac, const_cast<max::t_atom*>(av));
             if (d) {
                 max::attr_dictionary_process(self, d);
+                self->m_min_object.try_call("post_attribute_setup");
                 max::jbox_ready((max::t_jbox*)self);
             }
         }
         else {
             max::object_attach_byptr_register(
                 self, self, k_sym_box); // so that objects can get notifications about their own attributes
+            self->m_min_object.try_call("post_attribute_setup");
             max::attr_args_process(self, static_cast<short>(args.size()), const_cast<max::t_atom*>(args.begin()));
         }
         return self;


### PR DESCRIPTION
added a post_attribute_setup , which can run as part of the construction process but after the attributes are assigned their initial values.

This allows users to build objects set the starting values of its attributes programmatically.

per this post on the forum:
https://cycling74.com/forums/how-to-set-color-attribute-in-min-devkit?replyPage=1#reply-68e42962cd9372ab9a653161